### PR TITLE
Hide the AWS user secret input

### DIFF
--- a/src/Command/Provider/ConnectProviderCommand.php
+++ b/src/Command/Provider/ConnectProviderCommand.php
@@ -79,7 +79,7 @@ class ConnectProviderCommand extends AbstractCommand
 
         return !empty($credentials) ? $credentials : [
             'key' => $output->ask('Please enter your AWS user key'),
-            'secret' => $output->ask('Please enter your AWS user secret'),
+            'secret' => $output->askHidden('Please enter your AWS user secret'),
         ];
     }
 


### PR DESCRIPTION
This is essentially a password and should not unexpectedly show on the user's screen.