### PR TITLE
disable SftpConnectionProvider agent support if password specified

### DIFF
--- a/src/Command/Import/ImportUploadsCommand.php
+++ b/src/Command/Import/ImportUploadsCommand.php
@@ -192,7 +192,7 @@ class ImportUploadsCommand extends AbstractProjectCommand
             );
         } elseif ('sftp' === $parsedPath['scheme']) {
             return new SftpAdapter(
-                new SftpConnectionProvider($parsedPath['host'], $parsedPath['user'] ?? get_current_user(), $parsedPath['pass'] ?? null, null, null, $parsedPath['port'] ?? 22, true),
+                new SftpConnectionProvider($parsedPath['host'], $parsedPath['user'] ?? get_current_user(), $parsedPath['pass'] ?? null, null, null, $parsedPath['port'] ?? 22, $parsedPath['pass'] ? false : true),
                 $parsedPath['path'] ?? '/'
             );
         }


### PR DESCRIPTION
Workaround for SftpConnectionProvider forcing agent on (allow passwords when unsupported keys are present)

resolves #6 (partially)