### PR TITLE
Allow DeleteEnvironmentCommand to be run without interaction.

### DIFF
--- a/src/Command/Environment/DeleteEnvironmentCommand.php
+++ b/src/Command/Environment/DeleteEnvironmentCommand.php
@@ -16,6 +16,7 @@ namespace Ymir\Cli\Command\Environment;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Ymir\Cli\Command\AbstractProjectCommand;
 use Ymir\Cli\Console\OutputInterface;
 
@@ -36,7 +37,9 @@ class DeleteEnvironmentCommand extends AbstractProjectCommand
         $this
             ->setName(self::NAME)
             ->setDescription('Delete an environment')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The name of the environment to delete');
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The name of the environment to delete')
+            ->addOption('--confirm', null, InputOption::VALUE_NONE)
+            ->addOption('--delete-resources', null, InputOption::VALUE_NONE);
     }
 
     /**
@@ -46,11 +49,13 @@ class DeleteEnvironmentCommand extends AbstractProjectCommand
     {
         $environment = $this->determineEnvironment($input, $output);
 
-        if (!$output->confirm(sprintf('Are you sure you want to delete the "<comment>%s</comment>" environment?', $environment), false)) {
+        $confirm = $input->getOption('confirm') ?: $output->confirm(sprintf('Are you sure you want to delete the "<comment>%s</comment>" environment?', $environment), false);
+
+        if (!$confirm) {
             return;
         }
 
-        $deleteResources = $output->confirm('Do you want to delete all the environment resources on the cloud provider?', false);
+        $deleteResources = $input->getOption('delete-resources') ?: $output->confirm('Do you want to delete all the environment resources on the cloud provider?', false);
 
         $this->apiClient->deleteEnvironment($this->projectConfiguration->getProjectId(), $environment, $deleteResources);
 

--- a/tests/Unit/Command/Environment/DeleteEnvironmentCommandTest.php
+++ b/tests/Unit/Command/Environment/DeleteEnvironmentCommandTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Ymir command-line tool.
+ *
+ * (c) Carl Alexander <support@ymirapp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Command\Environment;
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Ymir\Cli\Command\Environment\DeleteEnvironmentCommand;
+use Ymir\Cli\Tests\Mock\ApiClientMockTrait;
+use Ymir\Cli\Tests\Mock\CliConfigurationMockTrait;
+use Ymir\Cli\Tests\Mock\ProjectConfigurationMockTrait;
+use Ymir\Cli\Tests\Unit\TestCase;
+
+/**
+ * @covers \Ymir\Cli\Command\Environment\DeleteEnvironmentCommand
+ */
+class DeleteEnvironmentCommandTest extends TestCase
+{
+    use ApiClientMockTrait;
+    use CliConfigurationMockTrait;
+    use ProjectConfigurationMockTrait;
+
+    public function testDeletesEnvironment()
+    {
+        $apiClient = $this->getApiClientMock();
+        $apiClient->expects($this->once())
+                  ->method('isAuthenticated')
+                  ->willReturn(true);
+        $cliConfiguration = $this->getCliConfigurationMock();
+        $projectConfiguration = $this->getProjectConfigurationMock();
+
+        $environment = $this->faker->word;
+
+        $apiClient->expects($this->once())
+                  ->method('getEnvironments')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()))
+                  ->willReturn(collect([['name' => $environment]]));
+
+        $apiClient->expects($this->once())
+                  ->method('deleteEnvironment')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()), $this->equalTo($environment), $this->equalTo(false));
+
+        $projectConfiguration->expects($this->once())
+                             ->method('deleteEnvironment')
+                             ->with($this->equalTo($environment));
+
+        $commandTester = new CommandTester(new DeleteEnvironmentCommand($apiClient, $cliConfiguration, $projectConfiguration));
+
+        $commandTester->setInputs([
+            'yes',
+            'no',
+        ]);
+
+        $commandTester->execute([
+            'environment' => $environment,
+        ], [
+            'interactive' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('Environment deleted', $commandTester->getDisplay());
+    }
+
+    public function testDeletesEnvironmentWithoutInteraction()
+    {
+        $apiClient = $this->getApiClientMock();
+        $apiClient->expects($this->once())
+                  ->method('isAuthenticated')
+                  ->willReturn(true);
+        $cliConfiguration = $this->getCliConfigurationMock();
+        $projectConfiguration = $this->getProjectConfigurationMock();
+
+        $environment = $this->faker->word;
+
+        $apiClient->expects($this->once())
+                  ->method('getEnvironments')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()))
+                  ->willReturn(collect([['name' => $environment]]));
+
+        $apiClient->expects($this->once())
+            ->method('deleteEnvironment')
+            ->with($this->equalTo($projectConfiguration->getProjectId()), $this->equalTo($environment), $this->equalTo(false));
+
+        $projectConfiguration->expects($this->once())
+                             ->method('deleteEnvironment')
+                             ->with($this->equalTo($environment));
+
+        $commandTester = new CommandTester(new DeleteEnvironmentCommand($apiClient, $cliConfiguration, $projectConfiguration));
+
+        $commandTester->execute([
+            'environment' => $environment,
+            '--confirm' => null,
+        ], [
+            'interactive' => false,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('Environment deleted', $commandTester->getDisplay());
+    }
+
+    public function testDeletesEnvironmentWithoutInteractionWithResources()
+    {
+        $apiClient = $this->getApiClientMock();
+        $apiClient->expects($this->once())
+            ->method('isAuthenticated')
+            ->willReturn(true);
+        $cliConfiguration = $this->getCliConfigurationMock();
+        $projectConfiguration = $this->getProjectConfigurationMock();
+
+        $environment = $this->faker->word;
+
+        $apiClient->expects($this->once())
+                  ->method('getEnvironments')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()))
+                  ->willReturn(collect([['name' => $environment]]));
+
+        $apiClient->expects($this->once())
+                  ->method('deleteEnvironment')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()), $this->equalTo($environment), $this->equalTo(true));
+
+        $projectConfiguration->expects($this->once())
+                             ->method('deleteEnvironment')
+                             ->with($this->equalTo($environment));
+
+        $commandTester = new CommandTester(new DeleteEnvironmentCommand($apiClient, $cliConfiguration, $projectConfiguration));
+
+        $commandTester->execute([
+            'environment' => $environment,
+            '--confirm' => null,
+            '--delete-resources' => null,
+        ], [
+            'interactive' => false,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('Environment deleted', $commandTester->getDisplay());
+    }
+
+    public function testDeletesEnvironmentWithResources()
+    {
+        $apiClient = $this->getApiClientMock();
+        $apiClient->expects($this->once())
+                  ->method('isAuthenticated')
+                  ->willReturn(true);
+        $cliConfiguration = $this->getCliConfigurationMock();
+        $projectConfiguration = $this->getProjectConfigurationMock();
+
+        $environment = $this->faker->word;
+
+        $apiClient->expects($this->once())
+                  ->method('getEnvironments')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()))
+                  ->willReturn(collect([['name' => $environment]]));
+
+        $apiClient->expects($this->once())
+                  ->method('deleteEnvironment')
+                  ->with($this->equalTo($projectConfiguration->getProjectId()), $this->equalTo($environment), $this->equalTo(true));
+
+        $projectConfiguration->expects($this->once())
+                             ->method('deleteEnvironment')
+                             ->with($this->equalTo($environment));
+
+        $commandTester = new CommandTester(new DeleteEnvironmentCommand($apiClient, $cliConfiguration, $projectConfiguration));
+
+        $commandTester->setInputs([
+            'yes',
+            'yes',
+        ]);
+
+        $commandTester->execute([
+            'environment' => $environment,
+        ], [
+            'interactive' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('Environment deleted', $commandTester->getDisplay());
+    }
+}


### PR DESCRIPTION
Commit checks fail because of some LoginCommand test issue but I think that is not my fault.