### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "league/flysystem-ftp": "^2.0|^3.0",
         "league/flysystem-sftp-v3": "^2.0|^3.0",
         "nesbot/carbon": "^2.72.6|^3.8.4",
-        "paragonie/random_compat": "^2.0",
         "phpseclib/phpseclib": "^3.0.36",
         "symfony/config": "^5.4|^6.0",
         "symfony/console": "^5.4|^6.0",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^2.0`, but also `php: >=7.2.5`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?